### PR TITLE
Update publish-package.yml

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
       - uses: phips28/gh-action-bump-version@master


### PR DESCRIPTION
give write permissions to action according to: https://github.com/phips28/gh-action-bump-version

```
# .github/workflows/[your_workflow].yml

jobs:
  publish:
    ...
    permissions:
      contents: write
```